### PR TITLE
Changes to allow color index with JXLS

### DIFF
--- a/JXLSCell.h
+++ b/JXLSCell.h
@@ -24,12 +24,16 @@
 -(void)setOrientation:(txtori_option_t)ori_option;
 -(void)setForegroundFillColor:(color_name_t)color;
 -(void)setBackgroundFillColor:(color_name_t)color;
+-(void)setBackgroundFillColorIndex:(unsigned8_t)color;
+-(void)setForegroundFillColorIndex:(unsigned8_t)color;
+
 -(void)setFillStyle:(fill_option_t)fill;
 -(void)setLocked:(BOOL)locked_opt;
 -(void)setHidden:(BOOL)hidden_opt;
 -(void)setWraps:(BOOL)wrap_opt;
 -(void)setBorderStyle:(border_style_t)style forSide:(border_side_t)side;
 -(void)setBorderColor:(color_name_t)color forSide:(border_side_t)side;
+-(void)setBorderColorIndex:(unsigned8_t)color forSide:(border_side_t)side;
 
 //font_i interface
 -(void)setFontName:(NSString *)name;
@@ -37,6 +41,7 @@
 -(void)setFontBold:(boldness_option_t)fntboldness;
 -(void)setFontUnderline:(underline_option_t)fntunderline;
 -(void)setFontColor:(color_name_t)fntcolor;
+-(void)setFontColorIndex:(unsigned8_t)fntcolor;
 -(void)setFontItalic:(BOOL)italic;
 -(void)setFontStrikeout:(BOOL)so;
 -(void)setFontOutline:(BOOL)ol;

--- a/JXLSCell.mm
+++ b/JXLSCell.mm
@@ -76,6 +76,15 @@ using namespace xlslib_strings;
 {
 	_cell->fillbgcolor(color);
 }
+
+-(void)setBackgroundFillColorIndex:(unsigned8_t)color {
+    _cell->fillbgcolor(color);
+}
+-(void)setForegroundFillColorIndex:(unsigned8_t)color {
+    _cell->fillfgcolor(color);
+}
+
+
 -(void)setFillStyle:(fill_option_t)fill
 {
 	_cell->fillstyle(fill);
@@ -99,6 +108,10 @@ using namespace xlslib_strings;
 -(void)setBorderColor:(color_name_t)color forSide:(border_side_t)side
 {
 	_cell->bordercolor(side, color);
+}
+-(void)setBorderColorIndex:(unsigned8_t)color forSide:(border_side_t)side
+{
+    _cell->bordercolor(side, color);
 }
 
 //font_i interface
@@ -126,6 +139,11 @@ using namespace xlslib_strings;
 {
 	_cell->fontcolor(fntcolor);
 }
+-(void)setFontColorIndex:(unsigned8_t)fntcolor
+{
+    _cell->fontcolor(fntcolor);
+}
+
 -(void)setFontItalic:(BOOL)italic
 {
 	_cell->fontitalic((bool)italic);

--- a/JXLSExtendedFormat.h
+++ b/JXLSExtendedFormat.h
@@ -30,8 +30,10 @@
 -(void)setTextOrientation:(txtori_option_t)ori_option;
 -(uint8_t)textOrientation;
 -(void)setForegroundFillColor:(color_name_t)color;
+-(void)setForegroundFillColorIndex:(unsigned8_t)color;
 -(uint8_t)foregroundFillColor;
 -(void)setBackgroundFillColor:(color_name_t)color;
+-(void)setBackgroundFillColorIndex:(unsigned8_t)color;
 -(uint8_t)backgroundFillColor;
 -(void)setFillStyle:(fill_option_t)fill;
 -(uint8_t)fillStyle;
@@ -42,6 +44,7 @@
 -(void)setWraps:(BOOL)wrap_opt;
 -(void)setBorderStyle:(border_style_t)style forSide:(border_side_t)side;
 -(void)setBorderColor:(color_name_t)color forSide:(border_side_t)side;
+-(void)setBorderColorIndex:(unsigned8_t)color forSide:(border_side_t)side;
 -(void)borderStyle:(border_side_t)side;
 
 @end

--- a/JXLSExtendedFormat.mm
+++ b/JXLSExtendedFormat.mm
@@ -111,6 +111,12 @@ using namespace xlslib_strings;
 {
 	_extFormat->SetFillFGColor(color);
 }
+
+-(void)setForegroundFillColorIndex:(unsigned8_t)color
+{
+    _extFormat->SetFillFGColor(color);
+}
+
 -(uint8_t)foregroundFillColor
 {
 	return _extFormat->GetFillFGColorIdx();
@@ -119,6 +125,10 @@ using namespace xlslib_strings;
 -(void)setBackgroundFillColor:(color_name_t)color
 {
 	_extFormat->SetFillBGColor(color);
+}
+-(void)setBackgroundFillColorIndex:(unsigned8_t)color
+{
+    _extFormat->SetFillBGColor(color);
 }
 -(uint8_t)backgroundFillColor
 {
@@ -165,6 +175,10 @@ using namespace xlslib_strings;
 -(void)setBorderColor:(color_name_t)color forSide:(border_side_t)side
 {
 	_extFormat->SetBorderColor(side, color);
+}
+-(void)setBorderColorIndex:(unsigned8_t)color forSide:(border_side_t)side
+{
+    _extFormat->SetBorderColor(side, color);
 }
 -(void)borderStyle:(border_side_t)side
 {

--- a/JXLSWorkBook.h
+++ b/JXLSWorkBook.h
@@ -27,4 +27,5 @@
 -(void)tabBarWidth:(uint16_t)width;									// void SetTabBarWidth(unsigned16_t width)
 
 -(int)writeToFile:(NSString *)fileName;								// int Dump(std::string filename);
+-(BOOL) setColorWithRed:(int) red green:(int) green blue:(int) blue index:(int) idx;
 @end

--- a/JXLSWorkBook.mm
+++ b/JXLSWorkBook.mm
@@ -170,4 +170,11 @@ using namespace xlslib_strings;
 	
 	return _workBook->Dump(filename);
 }
+
+#define WORKBOOK(a) ((xlslib_core::workbook *)(a))
+
+- (BOOL) setColorWithRed:(int) red green:(int) green blue:(int) blue index:(int) idx {
+    return WORKBOOK(_workBook)->setColor(red,green,blue,idx);
+}
+
 @end


### PR DESCRIPTION
The current JXLS code only allows color_name_t’s to be used for
defining color.  These few changes allow JXLS to use color index’s
everywhere color_name_t’s are used EXCEPT for in JXLSRange.  Currently,
the underlying xlslib does NOT include support for a color index in its
interface for “cellColor”.  If that is added, than a cellColorIndex
method could also be added.
